### PR TITLE
feat: Home, Finished 네비게이션 컨트롤러 생성

### DIFF
--- a/Hazzle/Hazzle/Base.lproj/Main.storyboard
+++ b/Hazzle/Hazzle/Base.lproj/Main.storyboard
@@ -11,11 +11,11 @@
         <scene sceneID="nn3-Nk-0RJ">
             <objects>
                 <viewControllerPlaceholder storyboardName="Home" referencedIdentifier="Home" id="Qdj-xN-Cxi" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Item" id="A8d-Kc-q7C"/>
+                    <navigationItem key="navigationItem" id="Xgc-Ab-W6C"/>
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="A0f-7N-rDR" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1501.449275362319" y="82.366071428571431"/>
+            <point key="canvasLocation" x="2501" y="-291"/>
         </scene>
         <!--Statistics-->
         <scene sceneID="DxH-7m-JJd">
@@ -25,17 +25,17 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mtk-px-TZC" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1517.3913043478262" y="169.41964285714286"/>
+            <point key="canvasLocation" x="858" y="985"/>
         </scene>
         <!--Finished-->
         <scene sceneID="3ml-JB-sE2">
             <objects>
                 <viewControllerPlaceholder storyboardName="Finished" referencedIdentifier="Finished" id="qVm-LC-RLg" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Item" id="Jjm-cY-vmi"/>
+                    <navigationItem key="navigationItem" id="t4l-bH-mtY"/>
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="r1Q-5S-QPG" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1513.0434782608697" y="123.88392857142857"/>
+            <point key="canvasLocation" x="2512" y="415"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="hZD-n8-odx">
@@ -43,18 +43,57 @@
                 <tabBarController automaticallyAdjustsScrollViewInsets="NO" id="JTU-Gj-I4q" sceneMemberID="viewController">
                     <toolbarItems/>
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="OuT-qr-Zbf">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>
                     <connections>
-                        <segue destination="Qdj-xN-Cxi" kind="relationship" relationship="viewControllers" id="aIf-yT-I0c"/>
-                        <segue destination="qVm-LC-RLg" kind="relationship" relationship="viewControllers" id="96q-nZ-fqF"/>
+                        <segue destination="9aK-QP-7me" kind="relationship" relationship="viewControllers" id="aIf-yT-I0c"/>
+                        <segue destination="Pw3-sX-vkq" kind="relationship" relationship="viewControllers" id="96q-nZ-fqF"/>
                         <segue destination="Svt-f0-0F4" kind="relationship" relationship="viewControllers" id="AXn-g8-S3X"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="a6f-pK-lCD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="857.97101449275374" y="139.95535714285714"/>
+        </scene>
+        <!--Item-->
+        <scene sceneID="Wkr-tm-7aC">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="9aK-QP-7me" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="A8d-Kc-q7C"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="gCs-KD-Tez">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="Qdj-xN-Cxi" kind="relationship" relationship="rootViewController" id="YVk-Hp-RoA"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="61d-8V-zFX" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1754" y="-291"/>
+        </scene>
+        <!--Item-->
+        <scene sceneID="aXe-qT-v9c">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Pw3-sX-vkq" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="Jjm-cY-vmi"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="fe9-3S-WBi">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="qVm-LC-RLg" kind="relationship" relationship="rootViewController" id="ulD-aD-699"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="HDb-C2-zEr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1754" y="415"/>
         </scene>
     </scenes>
 </document>

--- a/Hazzle/Hazzle/Finished/Finished.storyboard
+++ b/Hazzle/Hazzle/Finished/Finished.storyboard
@@ -8,7 +8,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--완성-->
+        <!--완성 갤러리-->
         <scene sceneID="4be-6y-OP1">
             <objects>
                 <viewController storyboardIdentifier="Finished" useStoryboardIdentifierAsRestorationIdentifier="YES" id="RHx-wd-AQO" customClass="FinishedViewController" customModule="Hazzle" customModuleProvider="target" sceneMemberID="viewController">
@@ -19,11 +19,30 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="완성" image="flag.fill" catalog="system" id="hqR-O7-smG"/>
+                    <navigationItem key="navigationItem" title="완성 갤러리" id="b4h-Xg-bju"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RnO-Ni-ddK" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="357" y="173"/>
+            <point key="canvasLocation" x="1266.6666666666667" y="172.76785714285714"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="ybb-mo-cG9">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="7IS-7r-jeH" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="FcO-zB-RC6">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="RHx-wd-AQO" kind="relationship" relationship="rootViewController" id="3h1-Ph-a0g"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Unc-Gu-zgR" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="356.52173913043481" y="172.76785714285714"/>
         </scene>
     </scenes>
     <resources>

--- a/Hazzle/Hazzle/Home/Home.storyboard
+++ b/Hazzle/Hazzle/Home/Home.storyboard
@@ -21,6 +21,11 @@
                     </view>
                     <tabBarItem key="tabBarItem" title="습관" image="house" catalog="system" id="6ns-X7-aSA"/>
                     <navigationItem key="navigationItem" title="습관" id="GG5-kR-sD4">
+                        <barButtonItem key="leftBarButtonItem" style="plain" systemItem="bookmarks" id="rU0-O6-VTH">
+                            <connections>
+                                <segue destination="wpp-wM-WY7" kind="show" id="hdd-o1-GRk"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" systemItem="add" id="9uI-IE-mDJ">
                             <connections>
                                 <segue destination="xAf-rW-boa" kind="show" id="Vop-6N-p6m"/>
@@ -62,6 +67,16 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vK3-Qo-XX7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="342.02898550724638" y="167.41071428571428"/>
+        </scene>
+        <!--HabitDetail-->
+        <scene sceneID="N0a-HU-XdL">
+            <objects>
+                <viewControllerPlaceholder storyboardName="HabitDetail" referencedIdentifier="HabitDetail" id="wpp-wM-WY7" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="7VC-dw-d3C"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="73d-YK-SMJ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2007" y="35"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
## 개요
Home, Finished 네비게이션 컨트롤러 생성

## 작업사항
이제 Main.storyboard는 건들이지 않고 작업해도 될 거 같습니다. HabitDetail은 임시로 좌측 상단에 책 아이콘으로 이동하게 연결해놨습니다!
| | |
| -- | -- |
| ![Simulator Screen Shot - iPhone 8 - 2020-10-26 at 19 07 42](https://user-images.githubusercontent.com/15073405/97159648-86ef8000-17be-11eb-9205-856d5542e3e5.png) | ![Simulator Screen Shot - iPhone 8 - 2020-10-26 at 19 02 43](https://user-images.githubusercontent.com/15073405/97159194-d5e8e580-17bd-11eb-9d1c-12ebd8ef8edd.png) |